### PR TITLE
[nvim] Update fugitive commands bound to gs, gb

### DIFF
--- a/stowed/.config/nvim/fnl/dotfiles/plugin/fugitive.fnl
+++ b/stowed/.config/nvim/fnl/dotfiles/plugin/fugitive.fnl
@@ -1,8 +1,8 @@
 (module dotfiles.plugin.fugitive
   {autoload {util dotfiles.util}})
 
-(util.nnoremap :gs "Gstatus")
-(util.nnoremap :gb "Gblame")
+(util.nnoremap :gs "Git")
+(util.nnoremap :gb "Git blame")
 (util.nnoremap :gd "Gdiff")
 (util.nnoremap :gp "Git push")
 (util.nnoremap :gl "Git pull")


### PR DESCRIPTION
Using your overall .config/nvim setup and your sync.sh script, I get
warnings about the commands used for <leader> gs and <leader> gb. I had
these changes locally and am submitting them upstream.

----

Obviously your personal dotfiles, so a "get off my lawn" reply would be completely understandable.

Thanks for making this public and for the recent rewrite that relies much more on Aniseed 🏆 